### PR TITLE
Clist command replaced

### DIFF
--- a/ProgramManagement/ProgramManagement.psd1
+++ b/ProgramManagement/ProgramManagement.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ProgramManagement.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.1'
+ModuleVersion = '1.3.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/ProgramManagement/ProgramManagement.psm1
+++ b/ProgramManagement/ProgramManagement.psm1
@@ -169,15 +169,14 @@ function Get-AllPackageInfo {
 
     # If the Chocolatey CmdLine is installed, get a list of programs installed via Chocolatey
     if ([bool]$(Get-Command choco -ErrorAction SilentlyContinue)) {
-        #$ChocolateyInstalledProgramsPrep = clist --local-only
         
         $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
         #$ProcessInfo.WorkingDirectory = $BinaryPath | Split-Path -Parent
-        $ProcessInfo.FileName = $(Get-Command clist).Source
+        $ProcessInfo.FileName = $(Get-Command choco).Source
         $ProcessInfo.RedirectStandardError = $true
         $ProcessInfo.RedirectStandardOutput = $true
         $ProcessInfo.UseShellExecute = $false
-        $ProcessInfo.Arguments = "--local-only"
+        $ProcessInfo.Arguments = "list"
         $Process = New-Object System.Diagnostics.Process
         $Process.StartInfo = $ProcessInfo
         $Process.Start() | Out-Null
@@ -1110,7 +1109,6 @@ function Install-Program {
 
     # Get-AllPackageInfo
     try {
-        #$null = clist --local-only
         $PackageManagerInstallObjects = Get-AllPackageInfo -ProgramName $ProgramName -ErrorAction SilentlyContinue
         [array]$ChocolateyInstalledProgramObjects = $PackageManagerInstallObjects.ChocolateyInstalledProgramObjects
         [array]$PSGetInstalledPackageObjects = $PackageManagerInstallObjects.PSGetInstalledPackageObjects
@@ -1417,7 +1415,7 @@ function Install-Program {
 
                 #$AllOutput | Export-CliXml "$HOME\CupInstallOutput.ps1"
                 
-                if (![bool]$($(clist --local-only $ProgramName) -match $ProgramName)) {
+                if (![bool]$($(choco list $ProgramName) -match $ProgramName)) {
                     if ($AllOutput -match "prerelease" -and $Arguments -notmatch '--pre') {
                         $CupArgs = "--pre -y"
                         $ChocoPrepScript = @(
@@ -1455,7 +1453,7 @@ function Install-Program {
                     }
                 }
                 
-                if (![bool]$($(clist --local-only $ProgramName) -match $ProgramName)) {
+                if (![bool]$($(choco list $ProgramName) -match $ProgramName)) {
                     throw "'cup $ProgramName $CupArgs' failed with the following Output:`n$AllOutputA`n$AllOutputB"
                 }
 
@@ -1473,7 +1471,7 @@ function Install-Program {
 
                 cup $ProgramName -y
 
-                if (![bool]$($(clist --local-only $ProgramName) -match $ProgramName)) {
+                if (![bool]$($(choco list $ProgramName) -match $ProgramName)) {
                     Write-Error "'cup $ProgramName -y' failed! Halting!"
                     Write-Warning "Please update Chocolatey via:`n    cup chocolatey -y"
                     $global:FunctionResult = "1"
@@ -1747,7 +1745,7 @@ function Install-Program {
                             $CheckInstallStatus.RegistryProperties.Count -ne 0)
                             ) {
                                 Write-Error "The PackageManagement/PowerShellGet installation did NOT uninstall cleanly!"
-                                Write-Warning "Please check...`n    Get-Package`n    clist --local-only`n    appwiz.cpl`n...for the following Programs...`n$($PackagesToUninstall -join "`n")"
+                                Write-Warning "Please check...`n    Get-Package`n    choco list`n    appwiz.cpl`n...for the following Programs...`n$($PackagesToUninstall -join "`n")"
                                 return
                             }
 
@@ -1928,7 +1926,7 @@ function Install-Program {
 
     if ($ChocoInstall) {
         $InstallManager = "choco.exe"
-        $InstallCheck = $(clist --local-only $ProgramName)[1]
+        $InstallCheck = $(choco list $ProgramName)[1]
     }
     if ($PMInstall -or [bool]$(Get-Package $ProgramName -ProviderName Chocolatey -ErrorAction SilentlyContinue)) {
         $InstallManager = "PowerShellGet"
@@ -2648,7 +2646,6 @@ function Uninstall-Program {
     }
 
     try {
-        #$null = clist --local-only
         $PackageManagerInstallObjects = Get-AllPackageInfo -ProgramName $ProgramName -ErrorAction SilentlyContinue
         [array]$ChocolateyInstalledProgramObjects = $PackageManagerInstallObjects.ChocolateyInstalledProgramObjects
         [array]$PSGetInstalledPackageObjects = $PackageManagerInstallObjects.PSGetInstalledPackageObjects

--- a/ProgramManagement/Public/Get-AllPackageInfo.ps1
+++ b/ProgramManagement/Public/Get-AllPackageInfo.ps1
@@ -147,7 +147,6 @@ function Get-AllPackageInfo {
 
     # If the Chocolatey CmdLine is installed, get a list of programs installed via Chocolatey
     if ([bool]$(Get-Command choco -ErrorAction SilentlyContinue)) {
-        #$ChocolateyInstalledProgramsPrep = clist --local-only
         
         $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
         #$ProcessInfo.WorkingDirectory = $BinaryPath | Split-Path -Parent
@@ -155,7 +154,7 @@ function Get-AllPackageInfo {
         $ProcessInfo.RedirectStandardError = $true
         $ProcessInfo.RedirectStandardOutput = $true
         $ProcessInfo.UseShellExecute = $false
-        $ProcessInfo.Arguments = "--local-only"
+        $ProcessInfo.Arguments = "list"
         $Process = New-Object System.Diagnostics.Process
         $Process.StartInfo = $ProcessInfo
         $Process.Start() | Out-Null

--- a/ProgramManagement/Public/Install-Program.ps1
+++ b/ProgramManagement/Public/Install-Program.ps1
@@ -509,7 +509,7 @@ function Install-Program {
 
                 #$AllOutput | Export-CliXml "$HOME\CupInstallOutput.ps1"
                 
-                if (![bool]$($(clist --local-only $ProgramName) -match $ProgramName)) {
+                if (![bool]$($(choco list $ProgramName) -match $ProgramName)) {
                     throw "'cup $ProgramName $CupArgs' failed with the following Output:`n$AllOutputA`n$AllOutputB"
                 }
 
@@ -532,7 +532,7 @@ function Install-Program {
                     return
                 }
 
-                if (![bool]$($(clist --local-only $ProgramName) -match $ProgramName)) {
+                if (![bool]$($(choco list $ProgramName) -match $ProgramName)) {
                     Write-Warning "Please start a new PowerShell session and update Chocolatey via:`n    cup chocolatey -y"
                     Write-Error "'cup $ProgramName -y' failed! Halting!"
                     return
@@ -630,7 +630,7 @@ function Install-Program {
 
     if ($UseChocoCheck) {
         $InstallManager = "choco.exe"
-        $InstallCheck = $(clist --local-only $ProgramName)[1]
+        $InstallCheck = $(choco list $ProgramName)[1]
     }
     if ($PMInstall -or [bool]$(Get-Package $ProgramName -ErrorAction SilentlyContinue)) {
         $InstallManager = "PowerShellGet"


### PR DESCRIPTION
I was trying to figure out a way to merge data from Uninstall Registry entries with Chocolatey entries and came across this project, first hurdle was usage of the "clist" alias which is no longer supported.

Now encountering an issue with the way it attempts to determine the last write date of the uninstall registry entries. I think PackageManagement's Get-Package command has changed dramatically and I know I can get the LastWriteDate by using Get-Item on the registry entries directly but haven't determined where to make an adjustment yet. Any insight would be helpful.

![image](https://github.com/pldmgg/ProgramManagement/assets/6981936/2f84c492-cce6-4e73-afd9-11803fdc06c4)